### PR TITLE
Don't fail on file-level comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ module.exports = function(source) {
   this.cacheable();
   var result = {};
   css.parse(source).stylesheet.rules
-    .filter(rule => rule.selectors.some(sel => sel === ':root'))
+    .filter(rule => rule.selectors && rule.selectors.some(sel => sel === ':root'))
     .forEach(rule => rule.declarations
       .filter(decl => decl.type === 'declaration' && decl.property.indexOf('--') === 0)
       .forEach(decl => result[decl.property] = decl.value));

--- a/test/simple.js
+++ b/test/simple.js
@@ -33,3 +33,6 @@ check('should import from :root among multiple selectors',
 check('should not break when there is a comment',
   ':root { --theme: red; /* important info */ --accent: blue }',
   { '--accent': 'blue', '--theme': 'red' })
+check('should not break when there is a file-level comment',
+  '/* file info */ :root { --theme: red; /* important info */ --accent: blue }',
+  { '--accent': 'blue', '--theme': 'red' })


### PR DESCRIPTION
The loader works great when there are comments within a selector, but
before this commit, if there were comments in a file that aren’t within
a selector, they were causing the loader to fail.

Such a comment doesn’t have any selectors, so this change simply checks
to see if `rule.selectors` is truth before continuing.

(Hope you don’t mind me sending this PR your way. I want to use this in one of my projects, but our coding standards require some file info in the header of a file, so I figured I’d see if I could make it work.)